### PR TITLE
updated the Versionnumber

### DIFF
--- a/data/misc/default.tex
+++ b/data/misc/default.tex
@@ -1,6 +1,6 @@
 \documentclass[11pt]{article}
 %Gummi|065|=)
-\title{\textbf{Welcome to Gummi 0.6.5}}
+\title{\textbf{Welcome to Gummi 0.7.1}}
 \author{Alexander van der Mey\\
 		Wei-Ning Huang\\
 		Dion Timmermann}
@@ -11,7 +11,7 @@
 
 \section{Before you start}
 
-You are now using Gummi 0.6.5. Many new exciting features have been added to the 0.6 series. The document editor is now a tabbed instance, allowing multiple documents to be worked on simultaneously. Using the new projects menu, you can group files together for easy access. 
+You are now using Gummi 0.7.1. Many new exciting features have been added to the 0.7 series. The document editor is now a tabbed instance, allowing multiple documents to be worked on simultaneously. Using the new projects menu, you can group files together for easy access. 
 
 Support for two high-level {\LaTeX} building systems, \emph{rubber}\footnote{https://launchpad.net/rubber/} \& \emph{latexmk}\footnote{http://www.phys.psu.edu/{\textasciitilde}collins/software/latexmk-jcc/} has been added to this release as well. Your preferred typesetter can be configured through the Compilation tab in the Preferences menu. Typesetters that are not installed on your system will not be selectable. 
 


### PR DESCRIPTION
besides the versionnumber the Welcome text could use an update, too.
I didnt want to change too much but i just loaded the gummi-gtk3 ppa to ubuntu and saw the old Version named in the Welcometext while the programinfo said its 7.1.

The Projectsite is down, too. So there might need some more to be sorted.