### PR TITLE
Fix AM_VERSION in autogen.sh.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-AM_VERSION=-`automake --version | head -n 1 | awk '{ print $NF }'`
+AM_VERSION=-`automake --version | head -n 1 | awk '{ print $NF }' | cut -d"." -f1,2`
 AC_VERSION=
 
 set -x


### PR DESCRIPTION
Fix AM_VERSION variable in order not to take also the revision number of the automake version

on Ubuntu 14.10

automake --version | head -n 1 | awk '{ print $NF }'

returns 1.14.1. So because of that final "1" the whole script fails.