### PR TITLE
Small ui bugfix

### DIFF
--- a/data/ui/gummi.glade
+++ b/data/ui/gummi.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.2 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="errorwindow">
@@ -1867,6 +1867,7 @@ active document to be saved. </property>
                                     <property name="xalign">0</property>
                                     <property name="xpad">10</property>
                                     <property name="label" translatable="yes">Root path:</property>
+                                    <property name="ellipsize">end</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">0</property>
@@ -1878,13 +1879,15 @@ active document to be saved. </property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="xalign">0</property>
+                                    <property name="xpad">10</property>
                                     <property name="label" translatable="yes">Project name:</property>
+                                    <property name="ellipsize">middle</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
+                                    <property name="left_attach">0</property>
                                     <property name="top_attach">0</property>
                                   </packing>
                                 </child>
@@ -1894,7 +1897,7 @@ active document to be saved. </property>
                                     <property name="can_focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="xpad">10</property>
-                                    <property name="ellipsize">start</property>
+                                    <property name="ellipsize">end</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
@@ -1925,9 +1928,6 @@ active document to be saved. </property>
                                     <property name="left_attach">1</property>
                                     <property name="top_attach">2</property>
                                   </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
@@ -2887,9 +2887,9 @@ bibliography database</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
                 <signal name="activate" handler="on_button_searchwindow_find_clicked" swapped="no"/>
-                <accelerator key="Escape" signal="activate" modifiers="GDK_SHIFT_MASK"/>
-                <accelerator key="Escape" signal="activate" modifiers="GDK_SHIFT_MASK"/>
                 <accelerator key="Return" signal="activate"/>
+                <accelerator key="Escape" signal="activate" modifiers="GDK_SHIFT_MASK"/>
+                <accelerator key="Escape" signal="activate" modifiers="GDK_SHIFT_MASK"/>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/src/project.c
+++ b/src/project.c
@@ -1,5 +1,5 @@
 /**
- * @file   project.h
+ * @file   project.c
  * @brief
  *
  * Copyright (C) 2009-2012 Gummi-Dev Team <alexvandermey@gmail.com>


### PR DESCRIPTION
Removed overlapping project label and project name.

Appareantly glade changed some parts too, the important lines are 1887-1890.
Now the label moves to the left so the label and proj_name dont overlap anymore.