### PR TITLE
Automatic PDF output only on tex files

### DIFF
--- a/src/gui/gui-main.c
+++ b/src/gui/gui-main.c
@@ -459,11 +459,13 @@ void gui_save_file(GuTabContext* tab, gboolean saveas)
   gtk_widget_grab_focus(focus);
 
   iofunctions_save_file(gummi->io, filename, text);
-
-  if (config_get_value("autoexport")) {
-    pdfname = g_strdup(filename);
-    pdfname[strlen(pdfname) - 4] = 0;
-    latex_export_pdffile(gummi->latex, tab->editor, pdfname, FALSE);
+  //verify that the file is a tex file to export to pdf 
+  if(strlen(filename)>4 && STR_EQU(filename + strlen(filename) - 4, ".tex")){
+    if (config_get_value("autoexport")) {
+      pdfname = g_strdup(filename);
+      pdfname[strlen(pdfname) - 4] = 0;
+      latex_export_pdffile(gummi->latex, tab->editor, pdfname, FALSE);
+    }
   }
   if (new) tabmanager_update_tab(filename);
   gui_set_filename_display(tab, TRUE, TRUE);

--- a/src/gui/gui-menu.c
+++ b/src/gui/gui-menu.c
@@ -177,8 +177,11 @@ void on_menu_export_activate(GtkWidget *widget, void *user)
   gchar* filename = NULL;
 
   filename = get_save_filename(TYPE_PDF);
-  if (filename)
-    latex_export_pdffile(gummi->latex, g_active_editor, filename, TRUE);
+  if (filename){
+    if(strlen(filename) > 4 && STR_EQU(filename + strlen(filename) - 4, ".tex")){
+      latex_export_pdffile(gummi->latex, g_active_editor, filename, TRUE);
+	 }
+  }
   g_free(filename);
 }
 


### PR DESCRIPTION
Changed the automatic PDF output feature to only output when the file name is .tex so it will not longer throw errors when opening tex related tex files like sty. 